### PR TITLE
Fix/allow single datasets when fetching

### DIFF
--- a/src/page/actions.js
+++ b/src/page/actions.js
@@ -10,13 +10,17 @@ export const getDatasets = createThunkAction(
         fetch(apiUrl)
         .then(response => response.json())
         .then(response => {
-          const datasets = wriAPISerializer(response);
+          const serializedDatasets = wriAPISerializer(response);
+          let datasets = serializedDatasets;
+          if (!Array.isArray(datasets)) {
+            datasets = [datasets];
+          }
           dispatch(setData({ datasets: datasets.map(d => ({ ...d, dataset: d.id })) }))
           const layers = datasets.map(d => ({
             dataset: d.id,
             opacity: 1,
             visible: true,
-            layer: d.layer && d.layer[0].id 
+            layer: d.layer && d.layer.length > 0 && d.layer[0].id 
           }))
           dispatch(setData({ layers }))
         })

--- a/src/page/index.js
+++ b/src/page/index.js
@@ -45,6 +45,8 @@ class Container extends PureComponent {
 
   handleSubmit = e => {
     e.preventDefault();
+    const { setData } = this.props;
+    setData({ layers: [] })
     this.getDatasets();
   }
 
@@ -76,7 +78,7 @@ class Container extends PureComponent {
   onChangeOpacity = (currentLayer, opacity) => {
     const { setData, layers } = this.props;
     setData({ layers: layers.map(l => {
-      let layer = l
+      let layer = { ...l }
       if (l.layer === currentLayer.id) {
         layer.opacity = opacity
       }
@@ -87,7 +89,7 @@ class Container extends PureComponent {
   onChangeVisibility = (currentLayer, visible) => {
     const { setData, layers } = this.props;
     setData({ layers: layers.map(l => {
-      let layer = l
+      let layer = { ...l }
       if (l.layer === currentLayer.id) {
         layer.visible = visible
       }

--- a/src/page/reducers.js
+++ b/src/page/reducers.js
@@ -1,7 +1,7 @@
 export const initialState = {
     datasets: [],
     layers: [],
-    apiUrl: 'https://api.resourcewatch.org/v1/dataset?application=rw&includes=metadata,vocabulary,layer&page[size]=3'
+    apiUrl: 'https://api.resourcewatch.org/v1/dataset?application=gfw&includes=layer&page[size]=5'
   };
   
   const setData = (state, { payload }) => ({

--- a/src/page/selectors.js
+++ b/src/page/selectors.js
@@ -7,19 +7,19 @@ const getLayers = state => state.layers
 export const getLayerGroups = createSelector(
   [getDatasets, getLayers],
   (datasets, layers) => {
-    if (!datasets && !datasets.length) return null
+    if (!datasets || !datasets.length || !layers || !layers.length) return null
     return layers.map(l => {
       const dataset = datasets.find(d => d.id === l.dataset)
       return {
         ...dataset,
-        layers: dataset.layer.map(layer => ({
+        layers: dataset.layer && dataset.layer.length > 0 ? dataset.layer.map(layer => ({
           ...layer,
           opacity: l.opacity,
           visible: l.visible,
           active: l.layer === layer.id
-        }))
+        })) : []
       }
-    })
+    }).filter(l => l.layers && l.layers.length > 0)
   }
 )
 


### PR DESCRIPTION
App was crashing when a single dataset is requested. This fixes that and makes sure to reset the layers in the store when refetching.