### PR TITLE
Feature/use react flow with redux to update layers

### DIFF
--- a/src/page/actions.js
+++ b/src/page/actions.js
@@ -19,7 +19,7 @@ export const getDatasets = createThunkAction(
             const layers = datasets.map(d => ({
               dataset: d.id,
               opacity: 1,
-              visible: true,
+              visibility: true,
               layer: d.layer && d.layer.length > 0 && d.layer[0].id 
             }))
             dispatch(setData({ layers }))

--- a/src/page/reducers.js
+++ b/src/page/reducers.js
@@ -1,7 +1,7 @@
 export const initialState = {
     datasets: [],
     layers: [],
-    apiUrl: 'https://api.resourcewatch.org/v1/dataset?application=rw&includes=layer&page[size]=3'
+    apiUrl: 'https://api.resourcewatch.org/v1/dataset?application=rw&includes=layer&page[size]=1'
   };
   
   const setData = (state, { payload }) => ({

--- a/src/page/selectors.js
+++ b/src/page/selectors.js
@@ -7,7 +7,7 @@ const getLayers = state => state.layers
 export const getLayerGroups = createSelector(
   [getDatasets, getLayers],
   (datasets, layers) => {
-    if (!datasets || !datasets.length || !layers || !layers.length) return null
+    if (!datasets || !datasets.length || !layers || !layers.length) return null;
     return layers.map(l => {
       const dataset = datasets.find(d => d.id === l.dataset)
       return {
@@ -15,7 +15,7 @@ export const getLayerGroups = createSelector(
         layers: dataset.layer && dataset.layer.length > 0 ? dataset.layer.map(layer => ({
           ...layer,
           opacity: l.opacity,
-          visible: l.visible,
+          visibility: l.visibility,
           active: l.layer === layer.id
         })) : []
       }


### PR DESCRIPTION
Update flow of data from store through selectors and comparisons to decide when to update layers. This prevents special cases arising with errors in the custom legend actions:
- remove layer manager specific functions from single actions
- use layers store key as single point of truth for layer/legend state
- add componentWillUpdate action to handle layer state changes